### PR TITLE
Add overwrite parameter

### DIFF
--- a/lib/fastlane/plugin/dropbox/actions/dropbox_action.rb
+++ b/lib/fastlane/plugin/dropbox/actions/dropbox_action.rb
@@ -28,7 +28,13 @@ module Fastlane
         chunk_size = 157_286_400 # 150 megabytes
 
         if File.size(params[:file_path]) < chunk_size
-          file = client.upload destination_path(params), File.read(params[:file_path])
+          if params[:overwrite]
+            file = client.upload(destination_path(params), File.read(params[:file_path]), {
+              :mode => :overwrite
+            })
+          else
+            file = client.upload destination_path(params), File.read(params[:file_path])
+          end
           output_file_name = file.name
         else
           parts = chunker params[:file_path], './part', chunk_size
@@ -148,6 +154,11 @@ module Fastlane
                                        description: 'Path to the destination Dropbox folder',
                                        type: String,
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :overwrite,
+                                       env_name: 'DROPBOX_OVERWRITE',
+                                       description: 'Overwrite file if exists on Dropbox',
+                                       type: Boolean,
+                                       optional: false),
           FastlaneCore::ConfigItem.new(key: :app_key,
                                        env_name: 'DROPBOX_APP_KEY',
                                        description: 'App Key of your Dropbox app',
@@ -195,6 +206,7 @@ module Fastlane
           'dropbox(
             file_path: "./path/to/file.txt",
             dropbox_path: "/My Dropbox Folder/Text files",
+            overwrite: "true/false",
             app_key: "dropbox-app-key",
             app_secret: "dropbox-app-secret"
           )'

--- a/lib/fastlane/plugin/dropbox/version.rb
+++ b/lib/fastlane/plugin/dropbox/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Dropbox
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/spec/dropbox_action_spec.rb
+++ b/spec/dropbox_action_spec.rb
@@ -10,6 +10,7 @@ describe Fastlane::Actions::DropboxAction do
   describe '#run' do
     let(:file_path) { '/path/to/file.txt' }
     let(:dropbox_path) { '/dropbox-folder' }
+    let(:overwrite) { 'true/false' }
     let(:destination_path) { "#{dropbox_path}/#{File.basename(file_path)}" }
     let(:file_data) { 'file-data' }
 
@@ -17,6 +18,7 @@ describe Fastlane::Actions::DropboxAction do
       {
         file_path: file_path,
         dropbox_path: dropbox_path,
+        overwrite: false,
         app_key: 'dropbox-app-key',
         app_secret: 'dropbox-app-secret',
         keychain: '/path/to/keychain',


### PR DESCRIPTION
Plugin action fails when the file is already exists.
Sometimes we need to overwrite the existing file for some reasons (to keep shared link, eg.,)
I added overwrite option to force overwrite file when the file is exists.
Default is 'false', not to overwrite and prints error as it was.

  