### PR TITLE
Allow access token as a parameter for CI purposes.

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -1,0 +1,32 @@
+name: Ruby Gem
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        version: 2.6.x
+
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}

--- a/spec/dropbox_action_spec.rb
+++ b/spec/dropbox_action_spec.rb
@@ -148,5 +148,114 @@ describe Fastlane::Actions::DropboxAction do
         end
       end
     end
+
+    describe 'access token' do
+      let(:params) do
+        {
+          file_path: file_path,
+          dropbox_path: dropbox_path,
+          write_mode: 'add',
+          update_rev: 'a1c10ce0dd78',
+          access_token: 'access-token'
+        }
+      end
+
+      let(:file_size) { 16_384 }
+
+      before do
+        allow(File).to receive(:size)
+          .with(params[:file_path])
+          .and_return(file_size)
+        allow(File).to receive(:read)
+          .with(params[:file_path])
+          .and_return(file_data)
+        allow(Fastlane::Actions::DropboxAction).to receive(:destination_path)
+          .and_return(destination_path)
+        allow_any_instance_of(DropboxApi::Client).to receive(:upload)
+          .and_return(output_file)
+      end
+
+      it 'should be uploaded to dropbox' do
+        expect(Fastlane::UI).to receive(:success).with("File revision: '#{output_file.rev}'")
+        expect(Fastlane::UI).to receive(:success).with("Successfully uploaded file to Dropbox at '#{output_file.path}'")
+        Fastlane::Actions::DropboxAction.run(params)
+      end
+    end
+
+    describe 'params validations' do
+      let(:params) do
+        {
+          file_path: file_path,
+          dropbox_path: dropbox_path,
+          write_mode: 'add',
+          update_rev: 'a1c10ce0dd78',
+          keychain: '/path/to/keychain',
+          keychain_password: 'very-secret-password'
+        }
+      end
+      let(:file_size) { 16_384 }
+
+      before do
+        allow(File).to receive(:size)
+          .with(params[:file_path])
+          .and_return(file_size)
+        allow(File).to receive(:read)
+          .with(params[:file_path])
+          .and_return(file_data)
+      end
+
+      context 'App key and secret' do
+        let(:params) do
+          super().merge(
+            app_key: 'dropbox-app-key',
+            app_secret: 'dropbox-app-secret'
+          )
+        end
+
+        include_context 'with valid parameters' do
+          it 'should be uploaded to dropbox' do
+            expect(Fastlane::UI).to receive(:success).with("File revision: '#{output_file.rev}'")
+            expect(Fastlane::UI).to receive(:success).with("Successfully uploaded file to Dropbox at '#{output_file.path}'")
+            Fastlane::Actions::DropboxAction.run(params)
+          end
+        end
+
+        context 'when missing app key' do
+          let(:params) do
+            super().merge(app_secret: 'dropbox-app-secret', app_key: nil)
+          end
+
+          it 'should throw user error' do
+            expect(Fastlane::UI).to receive(:user_error!).with("App Key not specified for Dropbox app. Provide your app's App Key or create a new app at https://www.dropbox.com/developers if you don't have an app yet.")
+            Fastlane::Actions::DropboxAction.run(params)
+          end
+        end
+
+        context 'when missing app secret' do
+          let(:params) do
+            super().merge(app_key: 'dropbox-app-key', app_secret: nil)
+          end
+
+          it 'should throw user error' do
+            expect(Fastlane::UI).to receive(:user_error!).with("App Secret not specified for Dropbox app. Provide your app's App Secret or create a new app at https://www.dropbox.com/developers if you don't have an app yet.")
+            Fastlane::Actions::DropboxAction.run(params)
+          end
+        end
+
+        context 'when access token' do
+          let(:params) do
+            super().merge(app_key: nil, app_secret: nil, access_token: 'token')
+          end
+
+          include_context 'with valid parameters' do
+            it 'should be uploaded to dropbox' do
+              expect(Fastlane::UI).to receive(:success).with("File revision: '#{output_file.rev}'")
+              expect(Fastlane::UI).to receive(:success).with("Successfully uploaded file to Dropbox at '#{output_file.path}'")
+              Fastlane::Actions::DropboxAction.run(params)
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Hack this together in order to allow to pass the access token as a parameter se we are be able to use this in our remote CI machine. 

Is there any other way to make it work for CI?